### PR TITLE
fix pin mapping of RAMPS-FD

### DIFF
--- a/MK4due/Pins.h
+++ b/MK4due/Pins.h
@@ -2391,21 +2391,21 @@
 #define ORIG_HEATER_1_PIN       10
 #define ORIG_HEATER_2_PIN       11
 
-#define ORIG_TEMP_BED_PIN        7   // ANALOG NUMBERING
+#define ORIG_TEMP_BED_PIN        0   // ANALOG NUMBERING
 
-#define ORIG_TEMP_0_PIN          6   // ANALOG NUMBERING
-#define ORIG_TEMP_1_PIN          5   // 2    // ANALOG NUMBERING
-#define ORIG_TEMP_2_PIN          4   // 3     // ANALOG NUMBERING
-#define ORIG_TEMP_3_PIN          3   // ANALOG NUMBERING
+#define ORIG_TEMP_0_PIN          1   // ANALOG NUMBERING
+#define ORIG_TEMP_1_PIN          2   // ANALOG NUMBERING
+#define ORIG_TEMP_2_PIN          3   // ANALOG NUMBERING
+#define ORIG_TEMP_3_PIN          4   // ANALOG NUMBERING
 
 #if NUM_SERVOS > 0
-  #define SERVO0_PIN            11
+  #define SERVO0_PIN             7
   #if NUM_SERVOS > 1
     #define SERVO1_PIN           6
     #if NUM_SERVOS > 2
       #define SERVO2_PIN         5
       #if NUM_SERVOS > 3
-        #define SERVO3_PIN       4
+        #define SERVO3_PIN       3
       #endif
     #endif
   #endif


### PR DESCRIPTION
source is here.
https://github.com/bobc/bobc_hardware/blob/master/RAMPS-FD/RAMPS-FD-Schematic.pdf

note:
analogue numbering in Marlin or Marlin-based firmwares differs from numbering in Repetier(for Due).

Marlin or Marlin-based firmwares | Repetier(for Due)
"A"0                             | "AD"7
"A"1                             | "AD"6
"A"2                             | "AD"5
"A"3                             | "AD"4
"A"4                             | "AD"3
"A"5                             | "AD"2
"A"6                             | "AD"1
"A"7                             | "AD"0
"A"8                             | "AD"10
"A"9                             | "AD"11
"A"10                            | "AD"12
"A"11                            | "AD"13

please see
http://forum.arduino.cc/index.php?topic=132130.0
.